### PR TITLE
Release v0.2.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -7,5 +7,5 @@ import (
 
 // Version returns current release version.
 func Version() string {
-	return "v0.1.0"
+	return "v0.2.0"
 }


### PR DESCRIPTION
This PR bumps `Version` to `v0.2.0` and pushes a corresponding tag.

There are 2 other packages whose releases "await" the new `nb` version, because they rely on some of the APIs introduced here.  I will update the Roadmap and examples in the `README` once those packages are published.