### PR TITLE
fix: change import path for goldmark-jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import (
 	synth "github.com/bevzzz/nb-synth"
 	"github.com/bevzzz/nb/extension"
 	"github.com/bevzzz/nb/extension/adapter"
-	jupyter "github.com/nb/extension/extra/goldmark-jupyter"
+	jupyter "github.com/bevzzz/nb/extension/extra/goldmark-jupyter"
 	"github.com/robert-nix/ansihtml"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"

--- a/extension/extra/goldmark-jupyter/attachment_test.go
+++ b/extension/extra/goldmark-jupyter/attachment_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bevzzz/nb"
 	"github.com/bevzzz/nb/pkg/test"
 	"github.com/bevzzz/nb/schema"
-	jupyter "github.com/nb/extension/extra/goldmark-jupyter"
+	jupyter "github.com/bevzzz/nb/extension/extra/goldmark-jupyter"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/renderer/html"

--- a/extension/extra/goldmark-jupyter/go.mod
+++ b/extension/extra/goldmark-jupyter/go.mod
@@ -1,4 +1,4 @@
-module github.com/nb/extension/extra/goldmark-jupyter
+module github.com/bevzzz/nb/extension/extra/goldmark-jupyter
 
 go 1.18
 


### PR DESCRIPTION
This could be a breaking change, but afaik nobody uses this package atm.
Also, `goldmark-jupyter` does not do semver, so I'm making it a simple fix instead.