### PR TITLE
docs(nbee): Update README.md

### DIFF
--- a/example/nbee/README.md
+++ b/example/nbee/README.md
@@ -7,7 +7,7 @@
 Compile the package on the fly 🐝
 
 ```sh
-go run github.com/bevzzz/nb/example/nbee -f path/to/notebook.ipynb
+go run github.com/bevzzz/nb/example/nbee@latest -f path/to/notebook.ipynb
 ```
 
 Or, install a binary 🗑


### PR DESCRIPTION
Both 'go run' and 'go install' should specify the target version, unless they are run from another Go-module directory (which is not required for this simple example)