### PR TITLE
Support earlier notebook versions

### DIFF
--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -38,9 +38,59 @@ func TestDecodeBytes(t *testing.T) {
 			nCells int
 		}{
 			{
+				name: "v4.5",
+				json: `{
+					"nbformat": 4, "nbformat_minor": 5, "metadata": {}, "cells": [
+						{"id": "a", "cell_type": "markdown", "metadata": {}, "source": []},
+						{"id": "b", "cell_type": "markdown", "metadata": {}, "source": []}
+					]
+				}`,
+				nCells: 2,
+			},
+			{
 				name: "v4.4",
 				json: `{
 					"nbformat": 4, "nbformat_minor": 4, "metadata": {}, "cells": [
+						{"cell_type": "markdown", "metadata": {}, "source": []},
+						{"cell_type": "markdown", "metadata": {}, "source": []}
+					]
+				}`,
+				nCells: 2,
+			},
+			{
+				name: "v4.3",
+				json: `{
+					"nbformat": 4, "nbformat_minor": 3, "metadata": {}, "cells": [
+						{"cell_type": "markdown", "metadata": {}, "source": []},
+						{"cell_type": "markdown", "metadata": {}, "source": []}
+					]
+				}`,
+				nCells: 2,
+			},
+			{
+				name: "v4.2",
+				json: `{
+					"nbformat": 4, "nbformat_minor": 2, "metadata": {}, "cells": [
+						{"cell_type": "markdown", "metadata": {}, "source": []},
+						{"cell_type": "markdown", "metadata": {}, "source": []}
+					]
+				}`,
+				nCells: 2,
+			},
+			{
+				name: "v4.1",
+				json: `{
+					"nbformat": 4, "nbformat_minor": 1, "metadata": {}, "cells": [
+						{"cell_type": "markdown", "metadata": {}, "source": []},
+						{"cell_type": "markdown", "metadata": {}, "source": []}
+					]
+				}`,
+				nCells: 2,
+			},
+			{
+				name: "v4.0",
+				json: `{
+					"nbformat": 4, "nbformat_minor": 0, "metadata": {}, "cells": [
 						{"cell_type": "markdown", "metadata": {}, "source": []},
 						{"cell_type": "markdown", "metadata": {}, "source": []}
 					]

--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -113,6 +113,36 @@ func TestDecodeBytes(t *testing.T) {
 				}`,
 				nCells: 3,
 			},
+			{
+				name: "v2.0",
+				json: `{
+					"nbformat": 2, "nbformat_minor": 0, "metadata": {}, "worksheets": [
+						{"cells": [
+							{"cell_type": "markdown", "metadata": {}, "source": []},
+							{"cell_type": "markdown", "metadata": {}, "source": []}
+						]},
+						{"cells": [
+							{"cell_type": "markdown", "metadata": {}, "source": []}
+						]}
+					]
+				}`,
+				nCells: 3,
+			},
+			{
+				name: "v1.0",
+				json: `{
+					"nbformat": 1, "nbformat_minor": 0, "metadata": {}, "worksheets": [
+						{"cells": [
+							{"cell_type": "markdown", "metadata": {}, "source": []},
+							{"cell_type": "markdown", "metadata": {}, "source": []}
+						]},
+						{"cells": [
+							{"cell_type": "markdown", "metadata": {}, "source": []}
+						]}
+					]
+				}`,
+				nCells: 3,
+			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				nb, err := decode.Bytes([]byte(tt.json))

--- a/schema/common/notebook.go
+++ b/schema/common/notebook.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Notebook struct {
-	VersionMajor int               `json:"nbformat"`
-	VersionMinor int               `json:"nbformat_minor"`
-	Metadata     json.RawMessage   `json:"metadata"` // TODO: omitempty
+	VersionMajor int             `json:"nbformat"`
+	VersionMinor int             `json:"nbformat_minor"`
+	Metadata     json.RawMessage `json:"metadata"` // TODO: omitempty
 }
 
 func (n *Notebook) Version() schema.Version {
@@ -25,3 +25,60 @@ const (
 	Stdout       = "application/vnd.jupyter.stdout" // Custom mime-type for stream output to stdout.
 	Stderr       = "application/vnd.jupyter.stderr" // Custom mime-type for stream output to stderr.
 )
+
+// Markdown defines the schema for a "markdown" cell.
+type Markdown struct {
+	Source MultilineString `json:"source"`
+}
+
+var _ schema.Cell = (*Markdown)(nil)
+
+func (md *Markdown) Type() schema.CellType {
+	return schema.Markdown
+}
+
+func (md *Markdown) MimeType() string {
+	return MarkdownText
+}
+
+func (md *Markdown) Text() []byte {
+	return md.Source.Text()
+}
+
+// Raw defines the schema for a "raw" cell.
+type Raw struct {
+	Source   MultilineString `json:"source"`
+	Metadata RawCellMetadata `json:"metadata"`
+}
+
+var _ schema.Cell = (*Raw)(nil)
+
+func (raw *Raw) Type() schema.CellType {
+	return schema.Raw
+}
+
+func (raw *Raw) MimeType() string {
+	return raw.Metadata.MimeType()
+}
+
+func (raw *Raw) Text() []byte {
+	return raw.Source.Text()
+}
+
+// RawCellMetadata may specify a target conversion format.
+type RawCellMetadata struct {
+	Format      *string `json:"format"`
+	RawMimeType *string `json:"raw_mimetype"`
+}
+
+// MimeType returns a more specific mime-type if one is provided and "text/plain" otherwise.
+func (raw *RawCellMetadata) MimeType() string {
+	switch {
+	case raw.Format != nil:
+		return *raw.Format
+	case raw.RawMimeType != nil:
+		return *raw.RawMimeType
+	default:
+		return PlainText
+	}
+}

--- a/schema/common/notebook.go
+++ b/schema/common/notebook.go
@@ -10,7 +10,6 @@ type Notebook struct {
 	VersionMajor int               `json:"nbformat"`
 	VersionMinor int               `json:"nbformat_minor"`
 	Metadata     json.RawMessage   `json:"metadata"` // TODO: omitempty
-	Cells        []json.RawMessage `json:"cells"`
 }
 
 func (n *Notebook) Version() schema.Version {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,3 +1,11 @@
+// Package schema defines the common data format for elements of a Jupyter notebook.
+//
+// It is based on the [v4.4] definition, as it is stable and encompasses all the data
+// necessary for accurate rendering. Note, that schema validation is not a goal of this
+// package, and so, interfaces defined here will often omit the non-essential data,
+// e.g. metadata or fields specific to JupyterLab environment. 
+//
+// [v4.4]: https://github.com/jupyter/nbformat/blob/main/nbformat/v4/nbformat.v4.4.schema.json
 package schema
 
 import (
@@ -34,6 +42,9 @@ type Cell interface {
 	Text() []byte
 }
 
+// HasAttachments is implemented by cells which include [cell attachments].
+//
+// [cell attachments]: https://nbformat.readthedocs.io/en/latest/format_description.html#cell-attachments
 type HasAttachments interface {
 	// Attachments are only defined for v4.0 and above for markdown and raw cells
 	// and may be omitted in the JSON. Cells without attachments should return nil.

--- a/schema/v3/schema.go
+++ b/schema/v3/schema.go
@@ -20,9 +20,11 @@ import (
 
 func init() {
 	decode.RegisterDecoder(schema.Version{Major: 3, Minor: 0}, new(decoder))
+	decode.RegisterDecoder(schema.Version{Major: 2, Minor: 0}, new(decoder))
+	decode.RegisterDecoder(schema.Version{Major: 1, Minor: 0}, new(decoder))
 }
 
-// decoder decodes cell contents and metadata for nbformat v3.0.
+// decoder decodes cell contents and metadata for nbformat v3.0, v2.0, and v1.0.
 type decoder struct{}
 
 var _ decode.Decoder = (*decoder)(nil)

--- a/schema/v3/schema.go
+++ b/schema/v3/schema.go
@@ -19,9 +19,10 @@ import (
 )
 
 func init() {
-	decode.RegisterDecoder(schema.Version{Major: 3, Minor: 0}, new(decoder))
-	decode.RegisterDecoder(schema.Version{Major: 2, Minor: 0}, new(decoder))
-	decode.RegisterDecoder(schema.Version{Major: 1, Minor: 0}, new(decoder))
+	d := new(decoder)
+	decode.RegisterDecoder(schema.Version{Major: 3, Minor: 0}, d)
+	decode.RegisterDecoder(schema.Version{Major: 2, Minor: 0}, d)
+	decode.RegisterDecoder(schema.Version{Major: 1, Minor: 0}, d)
 }
 
 // decoder decodes cell contents and metadata for nbformat v3.0, v2.0, and v1.0.

--- a/schema/v4/schema.go
+++ b/schema/v4/schema.go
@@ -17,12 +17,13 @@ import (
 )
 
 func init() {
-	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 5}, new(decoder))
-	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 4}, new(decoder))
-	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 3}, new(decoder))
-	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 2}, new(decoder))
-	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 1}, new(decoder))
-	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 0}, new(decoder))
+	d := new(decoder)
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 5}, d)
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 4}, d)
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 3}, d)
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 2}, d)
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 1}, d)
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 0}, d)
 }
 
 // decoder decodes cell contents and metadata for nbformat v4.0.

--- a/schema/v4/schema.go
+++ b/schema/v4/schema.go
@@ -11,12 +11,20 @@ import (
 )
 
 func init() {
-	decode.RegisterDecoder(version, new(decoder))
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 5}, new(decoder))
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 4}, new(decoder))
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 3}, new(decoder))
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 2}, new(decoder))
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 1}, new(decoder))
+	decode.RegisterDecoder(schema.Version{Major: 4, Minor: 0}, new(decoder))
 }
 
-var version = schema.Version{Major: 4, Minor: 4}
-
+// decoder decodes cell contents and metadata for nbformat v4.4.
+// Other versions can be decoded using the same, as their schema
+// differs in ways that does not affect how the notebook is rendered.
 type decoder struct{}
+
+var _ decode.Decoder = (*decoder)(nil)
 
 func (d *decoder) DecodeMeta(data []byte) (schema.NotebookMetadata, error) {
 	var nm NotebookMetadata

--- a/version.go
+++ b/version.go
@@ -8,5 +8,5 @@ import (
 
 // Version returns current release version.
 func Version() string {
-	return "v0.2.0"
+	return "v0.2.1"
 }

--- a/version.go
+++ b/version.go
@@ -2,6 +2,7 @@ package nb
 
 import (
 	// Currently supported nbformat versions:
+	_ "github.com/bevzzz/nb/schema/v3"
 	_ "github.com/bevzzz/nb/schema/v4"
 )
 


### PR DESCRIPTION
This PR adds decoders for Jupyter Notebooks `v4.*`, `v3.0`, `v2.0`, and `v1.0`.

It turns out v1 and v2 are not different from v3 in any way that affects the rendering, so the same decoder can be reused for all notebooks in the three formats.

BREAKING : `decode.Decoder` requires an additional method, so the existing implementations had to be updated.